### PR TITLE
Correction affichage demos

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -28,6 +28,12 @@
 
 /* Navigation*/
 
+.table_dl{
+  height:500px;
+  width:100%;
+  overflow:auto;/*pour activer les scrollbarres*/
+}
+
 .navbar {
     background-color: transparent;
 }

--- a/function.php
+++ b/function.php
@@ -422,8 +422,8 @@ function afficheDemo()
     $td_table .= '<tr>
     <th scope="row">'. $compteur .'</th>
     <td>'. $demo .'</td>
-    <td>'. date("d m Y", filemtime($chemin_demo.$demo)) .'</td>
-    <td>'. filesize($chemin_demo.$demo) .'</td>
+    <td>'. date("d/m/Y", filemtime($chemin_demo.$demo)) .'</td>
+    <td>'. affiche_taille(filesize($chemin_demo.$demo)) .'</td>
     <td>
     <fieldset class="form-group">
     <input name="demo_coche'. $compteur .'" value="'. $chemin_demo.$demo .'" type="checkbox">
@@ -451,4 +451,27 @@ function telechargeDemo($demos){
     }
     $zip->close();
   }
+}
+
+/**
+ * Affiche la taille d'un fichier et la met forme
+ *
+ * @param int $taille Taille du fichier en octet
+ *
+ * @return int
+*/
+function affiche_taille($taille) {
+	// $taille = intval($taille);
+	// $taille = (int)$taille;
+	// si le fichier à une taille supérieur à 2147483647, je le laisse en string car php ne lit pas les entiers plus lourd que 2147483647
+	$taille = ($taille < 2147483647) ? (int)$taille : $taille;
+	if ($taille<1024) { //octets
+		return number_format($taille, 0, ',', ' ').' octets';
+	}
+	else if ($taille < (1024*1024)) { //Ko
+		return number_format($taille/1024, 0, ',', ' ').' Ko';
+	}
+	else { //Mo
+		return number_format($taille/(1024*1024), 0, ',', ' ').' Mo';
+	}
 }

--- a/index.php
+++ b/index.php
@@ -48,6 +48,7 @@ require ('steamauth/steamauth.php');
 
     //téléchargement
     readfile("demos/download_demo.zip");
+    unlink("demos/download_demo.zip");
   }
   ?>
 
@@ -212,22 +213,34 @@ require ('steamauth/steamauth.php');
         <form method="post" action="">
           <!--Intro content-->
           <div class="full-bg-img flex-center">
-            <table class="table table_demos" style="text-align: left;">
-              <thead>
-                <tr>
-                  <th>#</th>
-                  <th>Nom</th>
-                  <th>Date</th>
-                  <th>Taille</th>
-                  <th></th>
-                </tr>
-              </thead>
-              <tbody>
-                <?php echo afficheDemo(); ?>
-              </tbody>
-            </table>
+            <div class="container">
+              <div class="row table_dl">
+                <table class="table table_demos" style="text-align: left;">
+                  <thead>
+                    <tr>
+                      <th>#</th>
+                      <th>Nom</th>
+                      <th>Date (d/m/Y)</th>
+                      <th>Taille</th>
+                      <th></th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <?php echo afficheDemo(); ?>
+                  </tbody>
+                </table>
+              </div>
+              <div class="row">
+                <div class="col">
+                </div>
+                <div class="col">
+                    <input class="btn btn-warning" type="submit" value="Télécharger les démos">
+                </div>
+                <div class="col">
+                </div>
+              </div>
+            </div>
           </div>
-          <input class="btn btn-warning bdl" type="submit" value="Télécharger les démos">
         </form>
       </div>
       <!--/.Demos-->


### PR DESCRIPTION
Le fichier download_demo.zip n'est pas supprimé après le transfert. Espace disque utilisé pour rien.
Le tableau déborde de l'écran, pas scrollable ni rien.
Le bouton "télécharger" reste en plein milieu du tableau quand il grandit.
Les tailles des démos sont reste en octets